### PR TITLE
Insert missing line in README code

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Automatically create GraphQL schema or customizable schema config fields from Dr
 
     const yoga = createYoga({ schema })
 
+    const server = createServer(yoga)
+
     server.listen(4000, () => {
         console.info('Server is running on http://localhost:4000/graphql')
     })


### PR DESCRIPTION
Adds a missing line in the README's example code. `server`'s instantiation was not present.