### PR TITLE
Return json array as string instead of array

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "drizzle-graphql",
 	"type": "module",
 	"author": "Drizzle Team",
-	"version": "0.8.5",
+	"version": "0.8.6",
 	"description": "Automatically generate GraphQL schema or customizable schema config fields from Drizzle ORM schema",
 	"scripts": {
 		"build": "pnpm tsx scripts/build.ts",

--- a/src/util/data-mappers/index.ts
+++ b/src/util/data-mappers/index.ts
@@ -26,6 +26,7 @@ export const remapToGraphQLCore = (
 			);
 		}
 		if (column.columnType === 'PgGeometry' || column.columnType === 'PgVector') return value;
+		if (column.columnType === 'PgJson' || column.columnType === 'PgJsonb') return JSON.stringify(value);
 
 		return value.map((arrVal) => remapToGraphQLCore(key, arrVal, tableName, column, relationMap));
 	}

--- a/tests/pg.test.ts
+++ b/tests/pg.test.ts
@@ -150,7 +150,8 @@ beforeEach(async () => {
 	await ctx.db.execute(sql`CREATE TABLE IF NOT EXISTS "posts" (
 		"id" serial PRIMARY KEY NOT NULL,
 		"content" text,
-		"author_id" integer
+		"author_id" integer,
+		"post_config" jsonb
 	);`);
 
 	await ctx.db.execute(sql`CREATE TABLE IF NOT EXISTS "users" (
@@ -217,11 +218,13 @@ beforeEach(async () => {
 			id: 1,
 			authorId: 1,
 			content: '1MESSAGE',
+			postConfig: ['config1', { configName: 'hello', configValue: 123 }],
 		},
 		{
 			id: 2,
 			authorId: 1,
 			content: '2MESSAGE',
+			postConfig: ['config2', { configName: 'hello', configValue: 123 }],
 		},
 		{
 			id: 3,
@@ -299,6 +302,7 @@ describe.sequential('Query tests', async () => {
 					id
 					authorId
 					content
+					postConfig
 				}
 			}
 		`);
@@ -330,6 +334,7 @@ describe.sequential('Query tests', async () => {
 					id: 1,
 					authorId: 1,
 					content: '1MESSAGE',
+					postConfig: '["config1",{"configName":"hello","configValue":123}]',
 				},
 			},
 		});

--- a/tests/schema/pg.ts
+++ b/tests/schema/pg.ts
@@ -5,6 +5,7 @@ import {
 	date,
 	geometry,
 	integer,
+	jsonb,
 	pgEnum,
 	pgTable,
 	serial,
@@ -53,6 +54,7 @@ export const Posts = pgTable('posts', {
 	id: serial('id').primaryKey(),
 	content: text('content'),
 	authorId: integer('author_id'),
+	postConfig: jsonb('post_config'),
 });
 
 export const usersRelations = relations(Users, ({ one, many }) => ({


### PR DESCRIPTION
## Description

- Fix issue where a JSON array is mistaken as an array when returned instead of a string. Fixes #29 