### PR TITLE
Expose Generated enum Types as Part of Entity Outputs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { MySqlDatabase } from 'drizzle-orm/mysql-core';
 import { PgDatabase } from 'drizzle-orm/pg-core';
 import { BaseSQLiteDatabase } from 'drizzle-orm/sqlite-core';
 import {
+	GraphQLEnumType,
 	GraphQLFieldConfig,
 	GraphQLInputObjectType,
 	GraphQLObjectType,
@@ -11,6 +12,7 @@ import {
 } from 'graphql';
 
 import { generateMySQL, generatePG, generateSQLite } from '@/util/builders';
+import { getEnumTypes } from '@/util/type-converter';
 import { ObjMap } from 'graphql/jsutils/ObjMap';
 import type { AnyDrizzleDB, BuildSchemaConfig, GeneratedData } from './types';
 
@@ -46,6 +48,13 @@ export const buildSchema = <TDbClient extends AnyDrizzleDB<any>>(
 	} else if (is(db, BaseSQLiteDatabase)) {
 		generatorOutput = generateSQLite(db, schema, config?.relationsDepthLimit);
 	} else throw new Error('Drizzle-GraphQL Error: Unknown database instance type');
+
+	const enums = getEnumTypes().reduce((enums, enumType) => {
+		enums[enumType.name] = enumType;
+		return enums;
+	}, {} as Record<string, GraphQLEnumType>);
+
+	generatorOutput.enums = enums;
 
 	const { queries, mutations, inputs, types } = generatorOutput;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ import type { RelationalQueryBuilder as PgQuery } from 'drizzle-orm/pg-core/quer
 import type { BaseSQLiteDatabase } from 'drizzle-orm/sqlite-core';
 import type { RelationalQueryBuilder as SQLiteQuery } from 'drizzle-orm/sqlite-core/query-builders/query';
 import type {
+	GraphQLEnumType,
 	GraphQLInputObjectType,
 	GraphQLList,
 	GraphQLNonNull,
@@ -384,6 +385,7 @@ export type GeneratedEntities<
 	>;
 	inputs: TInputs;
 	types: TOutputs;
+	enums: Record<string, GraphQLEnumType>;
 };
 
 export type GeneratedData<

--- a/src/util/type-converter/index.ts
+++ b/src/util/type-converter/index.ts
@@ -23,6 +23,7 @@ import type { ConvertedColumn } from './types';
 const allowedNameChars = /^[a-zA-Z0-9_]+$/;
 
 const enumMap = new WeakMap<Object, GraphQLEnumType>();
+const enumTypes = [] as GraphQLEnumType[];
 const generateEnumCached = (column: Column, columnName: string, tableName: string): GraphQLEnumType => {
 	if (enumMap.has(column)) return enumMap.get(column)!;
 
@@ -35,6 +36,7 @@ const generateEnumCached = (column: Column, columnName: string, tableName: strin
 	});
 
 	enumMap.set(column, gqlEnum);
+	enumTypes.push(gqlEnum);
 
 	return gqlEnum;
 };
@@ -144,5 +146,7 @@ export const drizzleColumnToGraphQLType = <TColumn extends Column, TIsInput exte
 
 	return typeDesc as ConvertedColumn<TIsInput>;
 };
+
+export const getEnumTypes = () => enumTypes;
 
 export * from './types';


### PR DESCRIPTION
When accessing the GraphQL types from `entities.types` it does not include the available enum types that where created from the database schema. This makes it difficult to reuse enum types that have been created in other input types of resolvers when working with custom schemas.

This pr adds a new property `enums` to the `entities` object containing the created enum types.