### PR TITLE
Add count queries

### DIFF
--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -1,6 +1,7 @@
 import {
 	and,
 	asc,
+	count,
 	desc,
 	eq,
 	getTableColumns,
@@ -692,4 +693,29 @@ export const extractRelationsParams = (
 	if (!info) return undefined;
 
 	return extractRelationsParamsInner(relationMap, tables, tableName, typeName, info, true);
+};
+
+export const executeCountQuery = async <TDb extends { select: Function; $count?: Function }>(
+	db: TDb,
+	table: Table,
+	where?: SQL,
+): Promise<number> => {
+	// Try to use the modern db.$count utility if available
+	if (db.$count && typeof db.$count === 'function') {
+		try {
+			const result = where
+				? await db.$count(table, where)
+				: await db.$count(table);
+			return Number(result) || 0;
+		} catch (e) {
+			// Fall back to manual count if $count fails
+		}
+	}
+
+	// Fall back to manual count query
+	const query = db.select({ count: count() }).from(table);
+	const result = await (where ? query.where(where) : query);
+	const value = result[0]?.count || 0;
+
+	return Number(value);
 };

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -15,6 +15,7 @@ import {
 	extractOrderBy,
 	extractRelationsParams,
 	extractSelectedColumnsFromTree,
+	executeCountQuery,
 	generateTableTypes,
 } from '@/util/builders/common';
 import { capitalize, uncapitalize } from '@/util/case-ops';
@@ -167,6 +168,41 @@ const generateSelectSingle = (
 				if (!result) return undefined;
 
 				return remapToGraphQLSingleOutput(result, tableName, table, relationMap);
+			} catch (e) {
+				if (typeof e === 'object' && typeof (<any> e).message === 'string') {
+					throw new GraphQLError((<any> e).message);
+				}
+
+				throw e;
+			}
+		},
+		args: queryArgs,
+	};
+};
+
+const generateSelectCount = (
+	db: MySqlDatabase<any, any, any, any>,
+	tableName: string,
+	tables: Record<string, Table>,
+	filterArgs: GraphQLInputObjectType,
+): CreatedResolver => {
+	const queryName = `${uncapitalize(tableName)}Count`;
+	const table = tables[tableName]!;
+
+	const queryArgs = {
+		where: {
+			type: filterArgs,
+		},
+	} as GraphQLFieldConfigArgumentMap;
+
+	return {
+		name: queryName,
+		resolver: async (source, args: { where?: Filters<Table> }, context, info) => {
+			try {
+				const { where } = args;
+
+				const whereClause = where ? extractFilters(table, tableName, where) : undefined;
+				return await executeCountQuery(db, table, whereClause);
 			} catch (e) {
 				if (typeof e === 'object' && typeof (<any> e).message === 'string') {
 					throw new GraphQLError((<any> e).message);
@@ -433,6 +469,12 @@ export const generateSchemaData = <
 			tableOrder,
 			tableFilters,
 		);
+		const selectCountGenerated = generateSelectCount(
+			db,
+			tableName,
+			tables,
+			tableFilters,
+		);
 		const insertArrGenerated = generateInsertArray(db, tableName, schema[tableName] as MySqlTable, insertInput);
 		const insertSingleGenerated = generateInsertSingle(db, tableName, schema[tableName] as MySqlTable, insertInput);
 		const updateGenerated = generateUpdate(
@@ -453,6 +495,11 @@ export const generateSchemaData = <
 			type: selectSingleOutput,
 			args: selectSingleGenerated.args,
 			resolve: selectSingleGenerated.resolver,
+		};
+		queries[selectCountGenerated.name] = {
+			type: GraphQLInt,
+			args: selectCountGenerated.args,
+			resolve: selectCountGenerated.resolver,
 		};
 		mutations[insertArrGenerated.name] = {
 			type: mutationReturnType,

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -15,6 +15,7 @@ import {
 	extractRelationsParams,
 	extractSelectedColumnsFromTree,
 	extractSelectedColumnsFromTreeSQLFormat,
+	executeCountQuery,
 	generateTableTypes,
 } from '@/util/builders/common';
 import { capitalize, uncapitalize } from '@/util/case-ops';
@@ -167,6 +168,41 @@ const generateSelectSingle = (
 				if (!result) return undefined;
 
 				return remapToGraphQLSingleOutput(result, tableName, table, relationMap);
+			} catch (e) {
+				if (typeof e === 'object' && typeof (<any> e).message === 'string') {
+					throw new GraphQLError((<any> e).message);
+				}
+
+				throw e;
+			}
+		},
+		args: queryArgs,
+	};
+};
+
+const generateSelectCount = (
+	db: PgDatabase<any, any, any>,
+	tableName: string,
+	tables: Record<string, Table>,
+	filterArgs: GraphQLInputObjectType,
+): CreatedResolver => {
+	const queryName = `${uncapitalize(tableName)}Count`;
+	const table = tables[tableName]!;
+
+	const queryArgs = {
+		where: {
+			type: filterArgs,
+		},
+	} as GraphQLFieldConfigArgumentMap;
+
+	return {
+		name: queryName,
+		resolver: async (source, args: { where?: Filters<Table> }, context, info) => {
+			try {
+				const { where } = args;
+
+				const whereClause = where ? extractFilters(table, tableName, where) : undefined;
+				return await executeCountQuery(db, table, whereClause);
 			} catch (e) {
 				if (typeof e === 'object' && typeof (<any> e).message === 'string') {
 					throw new GraphQLError((<any> e).message);
@@ -473,6 +509,12 @@ export const generateSchemaData = <
 			tableOrder,
 			tableFilters,
 		);
+		const selectCountGenerated = generateSelectCount(
+			db,
+			tableName,
+			tables,
+			tableFilters,
+		);
 		const insertArrGenerated = generateInsertArray(db, tableName, schema[tableName] as PgTable, insertInput);
 		const insertSingleGenerated = generateInsertSingle(db, tableName, schema[tableName] as PgTable, insertInput);
 		const updateGenerated = generateUpdate(db, tableName, schema[tableName] as PgTable, updateInput, tableFilters);
@@ -487,6 +529,11 @@ export const generateSchemaData = <
 			type: selectSingleOutput,
 			args: selectSingleGenerated.args,
 			resolve: selectSingleGenerated.resolver,
+		};
+		queries[selectCountGenerated.name] = {
+			type: GraphQLInt,
+			args: selectCountGenerated.args,
+			resolve: selectCountGenerated.resolver,
 		};
 		mutations[insertArrGenerated.name] = {
 			type: arrTableItemOutput,

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -15,6 +15,7 @@ import {
 	extractRelationsParams,
 	extractSelectedColumnsFromTree,
 	extractSelectedColumnsFromTreeSQLFormat,
+	executeCountQuery,
 	generateTableTypes,
 } from '@/util/builders/common';
 import { capitalize, uncapitalize } from '@/util/case-ops';
@@ -167,6 +168,41 @@ const generateSelectSingle = (
 				if (!result) return undefined;
 
 				return remapToGraphQLSingleOutput(result, tableName, table, relationMap);
+			} catch (e) {
+				if (typeof e === 'object' && typeof (<any> e).message === 'string') {
+					throw new GraphQLError((<any> e).message);
+				}
+
+				throw e;
+			}
+		},
+		args: queryArgs,
+	};
+};
+
+const generateSelectCount = (
+	db: BaseSQLiteDatabase<any, any, any, any>,
+	tableName: string,
+	tables: Record<string, Table>,
+	filterArgs: GraphQLInputObjectType,
+): CreatedResolver => {
+	const queryName = `${uncapitalize(tableName)}Count`;
+	const table = tables[tableName]!;
+
+	const queryArgs = {
+		where: {
+			type: filterArgs,
+		},
+	} as GraphQLFieldConfigArgumentMap;
+
+	return {
+		name: queryName,
+		resolver: async (source, args: { where?: Filters<Table> }, context, info) => {
+			try {
+				const { where } = args;
+
+				const whereClause = where ? extractFilters(table, tableName, where) : undefined;
+				return await executeCountQuery(db, table, whereClause);
 			} catch (e) {
 				if (typeof e === 'object' && typeof (<any> e).message === 'string') {
 					throw new GraphQLError((<any> e).message);
@@ -474,6 +510,12 @@ export const generateSchemaData = <
 			tableOrder,
 			tableFilters,
 		);
+		const selectCountGenerated = generateSelectCount(
+			db,
+			tableName,
+			tables,
+			tableFilters,
+		);
 		const insertArrGenerated = generateInsertArray(db, tableName, schema[tableName] as SQLiteTable, insertInput);
 		const insertSingleGenerated = generateInsertSingle(db, tableName, schema[tableName] as SQLiteTable, insertInput);
 		const updateGenerated = generateUpdate(
@@ -494,6 +536,11 @@ export const generateSchemaData = <
 			type: selectSingleOutput,
 			args: selectSingleGenerated.args,
 			resolve: selectSingleGenerated.resolver,
+		};
+		queries[selectCountGenerated.name] = {
+			type: GraphQLInt,
+			args: selectCountGenerated.args,
+			resolve: selectCountGenerated.resolver,
 		};
 		mutations[insertArrGenerated.name] = {
 			type: arrTableItemOutput,

--- a/tests/mysql-custom.test.ts
+++ b/tests/mysql-custom.test.ts
@@ -988,7 +988,7 @@ describe.sequential('Query tests', async () => {
 					...PostsFrag
 				}
 			}
-			
+
 			fragment UsersFrag on UsersSelectItem {
 				id
 				name
@@ -1107,7 +1107,7 @@ describe.sequential('Query tests', async () => {
 					...PostsFrag
 				}
 			}
-			
+
 			fragment UsersFrag on UsersSelectItem {
 				id
 				name
@@ -2003,6 +2003,47 @@ describe.sequential('Arguments tests', async () => {
 						],
 					},
 				],
+			},
+		});
+	});
+
+	it('Count queries', async () => {
+		// Test basic count
+		const countRes = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				customUsersCount
+			}
+		`);
+
+		expect(countRes).toStrictEqual({
+			data: {
+				customUsersCount: 2,
+			},
+		});
+
+		// Test count with filters
+		const filteredCountRes = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				customUsersCount(where: { role: { eq: "admin" } })
+			}
+		`);
+
+		expect(filteredCountRes).toStrictEqual({
+			data: {
+				customUsersCount: 1,
+			},
+		});
+
+		// Test posts count
+		const postsCountRes = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				customPostsCount
+			}
+		`);
+
+		expect(postsCountRes).toStrictEqual({
+			data: {
+				customPostsCount: 6,
 			},
 		});
 	});

--- a/tests/mysql.test.ts
+++ b/tests/mysql.test.ts
@@ -973,7 +973,7 @@ describe.sequential('Query tests', async () => {
 					...PostsFrag
 				}
 			}
-			
+
 			fragment UsersFrag on UsersSelectItem {
 				id
 				name
@@ -1092,7 +1092,7 @@ describe.sequential('Query tests', async () => {
 					...PostsFrag
 				}
 			}
-			
+
 			fragment UsersFrag on UsersSelectItem {
 				id
 				name
@@ -4596,5 +4596,46 @@ describe.sequential('__typename with data tests', async () => {
 		const data = await ctx.db.select().from(schema.Customers);
 
 		expect(data).toStrictEqual([]);
+	});
+
+	it('Count queries', async () => {
+		// Test basic count
+		const countRes = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				usersCount
+			}
+		`);
+
+		expect(countRes).toStrictEqual({
+			data: {
+				usersCount: 2,
+			},
+		});
+
+		// Test count with filters
+		const filteredCountRes = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				usersCount(where: { role: { eq: "admin" } })
+			}
+		`);
+
+		expect(filteredCountRes).toStrictEqual({
+			data: {
+				usersCount: 1,
+			},
+		});
+
+		// Test posts count
+		const postsCountRes = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				postsCount
+			}
+		`);
+
+		expect(postsCountRes).toStrictEqual({
+			data: {
+				postsCount: 6,
+			},
+		});
 	});
 });

--- a/tests/pg-custom.test.ts
+++ b/tests/pg-custom.test.ts
@@ -2051,4 +2051,45 @@ describe.sequential('Arguments tests', async () => {
 			},
 		});
 	});
+
+	it('Count queries', async () => {
+		// Test basic count
+		const countRes = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				customUsersCount
+			}
+		`);
+
+		expect(countRes).toStrictEqual({
+			data: {
+				customUsersCount: 2,
+			},
+		});
+
+		// Test count with filters
+		const filteredCountRes = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				customUsersCount(where: { role: { eq: "admin" } })
+			}
+		`);
+
+		expect(filteredCountRes).toStrictEqual({
+			data: {
+				customUsersCount: 1,
+			},
+		});
+
+		// Test posts count
+		const postsCountRes = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				customPostsCount
+			}
+		`);
+
+		expect(postsCountRes).toStrictEqual({
+			data: {
+				customPostsCount: 6,
+			},
+		});
+	});
 });

--- a/tests/pg.test.ts
+++ b/tests/pg.test.ts
@@ -1605,7 +1605,7 @@ describe.sequential('Query tests', async () => {
 							x: 20
 							y: 20.3
 						}
-						geoTuple: [20, 20.3]		
+						geoTuple: [20, 20.3]
 					}
 				) {
 					a
@@ -4279,6 +4279,47 @@ describe.sequential('__typename with data tests', async () => {
 						__typename: 'CustomersItem',
 					},
 				],
+			},
+		});
+	});
+
+	it('Count queries', async () => {
+		// Test basic count
+		const countRes = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				usersCount
+			}
+		`);
+
+		expect(countRes).toStrictEqual({
+			data: {
+				usersCount: 3,
+			},
+		});
+
+		// Test count with filters
+		const filteredCountRes = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				usersCount(where: { role: { eq: "admin" } })
+			}
+		`);
+
+		expect(filteredCountRes).toStrictEqual({
+			data: {
+				usersCount: 1,
+			},
+		});
+
+		// Test posts count
+		const postsCountRes = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				postsCount
+			}
+		`);
+
+		expect(postsCountRes).toStrictEqual({
+			data: {
+				postsCount: 6,
 			},
 		});
 	});

--- a/tests/sqlite-custom.test.ts
+++ b/tests/sqlite-custom.test.ts
@@ -1953,4 +1953,45 @@ describe.sequential('Arguments tests', async () => {
 			},
 		});
 	});
+
+	it('Count queries', async () => {
+		// Test basic count
+		const countRes = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				customUsersCount
+			}
+		`);
+
+		expect(countRes).toStrictEqual({
+			data: {
+				customUsersCount: 2,
+			},
+		});
+
+		// Test count with filters
+		const filteredCountRes = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				customUsersCount(where: { role: { eq: "admin" } })
+			}
+		`);
+
+		expect(filteredCountRes).toStrictEqual({
+			data: {
+				customUsersCount: 1,
+			},
+		});
+
+		// Test posts count
+		const postsCountRes = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				customPostsCount
+			}
+		`);
+
+		expect(postsCountRes).toStrictEqual({
+			data: {
+				customPostsCount: 6,
+			},
+		});
+	});
 });

--- a/tests/sqlite.test.ts
+++ b/tests/sqlite.test.ts
@@ -3746,4 +3746,45 @@ describe.sequential('__typename with data tests', async () => {
 			},
 		});
 	});
+
+	it('Count queries', async () => {
+		// Test basic count
+		const countRes = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				usersCount
+			}
+		`);
+
+		expect(countRes).toStrictEqual({
+			data: {
+				usersCount: 2,
+			},
+		});
+
+		// Test count with filters
+		const filteredCountRes = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				usersCount(where: { role: { eq: "admin" } })
+			}
+		`);
+
+		expect(filteredCountRes).toStrictEqual({
+			data: {
+				usersCount: 1,
+			},
+		});
+
+		// Test posts count
+		const postsCountRes = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				postsCount
+			}
+		`);
+
+		expect(postsCountRes).toStrictEqual({
+			data: {
+				postsCount: 6,
+			},
+		});
+	});
 });


### PR DESCRIPTION
In order to not introduce breaking changes on list responses, Count queries are added on the same level where `<table>Single` is generated as `<table>Count`. They use the same `where` filters as list, but return item count number only.