### PR TITLE
Add configurable suffixes for GraphQL naming

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,13 +38,24 @@ export const buildSchema = <TDbClient extends AnyDrizzleDB<any>>(
 		}
 	}
 
+	const suffixes = {
+		list: config?.suffixes?.list ?? '',
+		single: config?.suffixes?.single ?? 'Single',
+	};
+
+	if (suffixes.list === suffixes.single) {
+		throw new Error(
+			'Drizzle-GraphQL Error: List and single query suffixes cannot be the same. This would create conflicting GraphQL field names.',
+		);
+	}
+
 	let generatorOutput;
 	if (is(db, MySqlDatabase)) {
-		generatorOutput = generateMySQL(db, schema, config?.relationsDepthLimit);
+		generatorOutput = generateMySQL(db, schema, config?.relationsDepthLimit, suffixes);
 	} else if (is(db, PgDatabase)) {
-		generatorOutput = generatePG(db, schema, config?.relationsDepthLimit);
+		generatorOutput = generatePG(db, schema, config?.relationsDepthLimit, suffixes);
 	} else if (is(db, BaseSQLiteDatabase)) {
-		generatorOutput = generateSQLite(db, schema, config?.relationsDepthLimit);
+		generatorOutput = generateSQLite(db, schema, config?.relationsDepthLimit, suffixes);
 	} else throw new Error('Drizzle-GraphQL Error: Unknown database instance type');
 
 	const { queries, mutations, inputs, types } = generatorOutput;

--- a/src/types.ts
+++ b/src/types.ts
@@ -414,4 +414,15 @@ export type BuildSchemaConfig = {
 	 * Value is treated as if set to `undefined` by default.
 	 */
 	relationsDepthLimit?: number;
+	/**
+	 * Customizes query name suffixes for generated GraphQL operations.
+	 *
+	 * @default { list: '', single: 'Single' }
+	 */
+	suffixes?: {
+		/** Suffix for list queries (e.g., 'users' -> 'users' + suffix) */
+		list?: string;
+		/** Suffix for single queries (e.g., 'users' -> 'users' + suffix) */
+		single?: string;
+	};
 };

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -39,8 +39,9 @@ const generateSelectArray = (
 	relationMap: Record<string, Record<string, TableNamedRelations>>,
 	orderArgs: GraphQLInputObjectType,
 	filterArgs: GraphQLInputObjectType,
+	listSuffix: string,
 ): CreatedResolver => {
-	const queryName = `${uncapitalize(tableName)}`;
+	const queryName = `${uncapitalize(tableName)}${listSuffix}`;
 	const queryBase = db.query[tableName as keyof typeof db.query] as unknown as
 		| RelationalQueryBuilder<any, any, any>
 		| undefined;
@@ -114,8 +115,9 @@ const generateSelectSingle = (
 	relationMap: Record<string, Record<string, TableNamedRelations>>,
 	orderArgs: GraphQLInputObjectType,
 	filterArgs: GraphQLInputObjectType,
+	singleSuffix: string,
 ): CreatedResolver => {
-	const queryName = `${uncapitalize(tableName)}Single`;
+	const queryName = `${uncapitalize(tableName)}${singleSuffix}`;
 	const queryBase = db.query[tableName as keyof typeof db.query] as unknown as
 		| RelationalQueryBuilder<any, any, any>
 		| undefined;
@@ -346,6 +348,7 @@ export const generateSchemaData = <
 	db: TDrizzleInstance,
 	schema: TSchema,
 	relationsDepthLimit: number | undefined,
+	suffixes: { list: string; single: string },
 ): GeneratedEntities<TDrizzleInstance, TSchema> => {
 	const rawSchema = schema;
 	const schemaEntries = Object.entries(rawSchema);
@@ -424,6 +427,7 @@ export const generateSchemaData = <
 			namedRelations,
 			tableOrder,
 			tableFilters,
+			suffixes.list,
 		);
 		const selectSingleGenerated = generateSelectSingle(
 			db,
@@ -432,6 +436,7 @@ export const generateSchemaData = <
 			namedRelations,
 			tableOrder,
 			tableFilters,
+			suffixes.single,
 		);
 		const insertArrGenerated = generateInsertArray(db, tableName, schema[tableName] as MySqlTable, insertInput);
 		const insertSingleGenerated = generateInsertSingle(db, tableName, schema[tableName] as MySqlTable, insertInput);

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -39,8 +39,9 @@ const generateSelectArray = (
 	relationMap: Record<string, Record<string, TableNamedRelations>>,
 	orderArgs: GraphQLInputObjectType,
 	filterArgs: GraphQLInputObjectType,
+	listSuffix: string,
 ): CreatedResolver => {
-	const queryName = `${uncapitalize(tableName)}`;
+	const queryName = `${uncapitalize(tableName)}${listSuffix}`;
 	const queryBase = db.query[tableName as keyof typeof db.query] as unknown as
 		| RelationalQueryBuilder<any, any, any>
 		| undefined;
@@ -114,8 +115,9 @@ const generateSelectSingle = (
 	relationMap: Record<string, Record<string, TableNamedRelations>>,
 	orderArgs: GraphQLInputObjectType,
 	filterArgs: GraphQLInputObjectType,
+	singleSuffix: string,
 ): CreatedResolver => {
-	const queryName = `${uncapitalize(tableName)}Single`;
+	const queryName = `${uncapitalize(tableName)}${singleSuffix}`;
 	const queryBase = db.query[tableName as keyof typeof db.query] as unknown as
 		| RelationalQueryBuilder<any, any, any>
 		| undefined;
@@ -394,6 +396,7 @@ export const generateSchemaData = <
 	db: TDrizzleInstance,
 	schema: TSchema,
 	relationsDepthLimit: number | undefined,
+	suffixes: { list: string; single: string },
 ): GeneratedEntities<TDrizzleInstance, TSchema> => {
 	const rawSchema = schema;
 	const schemaEntries = Object.entries(rawSchema);
@@ -464,6 +467,7 @@ export const generateSchemaData = <
 			namedRelations,
 			tableOrder,
 			tableFilters,
+			suffixes.list,
 		);
 		const selectSingleGenerated = generateSelectSingle(
 			db,
@@ -472,6 +476,7 @@ export const generateSchemaData = <
 			namedRelations,
 			tableOrder,
 			tableFilters,
+			suffixes.single,
 		);
 		const insertArrGenerated = generateInsertArray(db, tableName, schema[tableName] as PgTable, insertInput);
 		const insertSingleGenerated = generateInsertSingle(db, tableName, schema[tableName] as PgTable, insertInput);

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -39,8 +39,9 @@ const generateSelectArray = (
 	relationMap: Record<string, Record<string, TableNamedRelations>>,
 	orderArgs: GraphQLInputObjectType,
 	filterArgs: GraphQLInputObjectType,
+	listSuffix: string,
 ): CreatedResolver => {
-	const queryName = `${uncapitalize(tableName)}`;
+	const queryName = `${uncapitalize(tableName)}${listSuffix}`;
 	const queryBase = db.query[tableName as keyof typeof db.query] as unknown as
 		| RelationalQueryBuilder<any, any, any>
 		| undefined;
@@ -114,8 +115,9 @@ const generateSelectSingle = (
 	relationMap: Record<string, Record<string, TableNamedRelations>>,
 	orderArgs: GraphQLInputObjectType,
 	filterArgs: GraphQLInputObjectType,
+	singleSuffix: string,
 ): CreatedResolver => {
-	const queryName = `${uncapitalize(tableName)}Single`;
+	const queryName = `${uncapitalize(tableName)}${singleSuffix}`;
 	const queryBase = db.query[tableName as keyof typeof db.query] as unknown as
 		| RelationalQueryBuilder<any, any, any>
 		| undefined;
@@ -395,6 +397,7 @@ export const generateSchemaData = <
 	db: TDrizzleInstance,
 	schema: TSchema,
 	relationsDepthLimit: number | undefined,
+	suffixes: { list: string; single: string },
 ): GeneratedEntities<TDrizzleInstance, TSchema> => {
 	const rawSchema = schema;
 	const schemaEntries = Object.entries(rawSchema);
@@ -465,6 +468,7 @@ export const generateSchemaData = <
 			namedRelations,
 			tableOrder,
 			tableFilters,
+			suffixes.list,
 		);
 		const selectSingleGenerated = generateSelectSingle(
 			db,
@@ -473,6 +477,7 @@ export const generateSchemaData = <
 			namedRelations,
 			tableOrder,
 			tableFilters,
+			suffixes.single,
 		);
 		const insertArrGenerated = generateInsertArray(db, tableName, schema[tableName] as SQLiteTable, insertInput);
 		const insertSingleGenerated = generateInsertSingle(db, tableName, schema[tableName] as SQLiteTable, insertInput);


### PR DESCRIPTION
Mainly, wanted to add customizable naming to GraphQL schema and don't break existing code, so single entity suffix is still "Single", list suffix is "" by default.

My projects use singular naming for entities (eg "user", "account"), so naturally I'd like to see suffixes like this as default behavior is a bit confusing: 

```
suffixes: {
  list: 's',
  single: '',
},
```